### PR TITLE
Remove articles entirely from combatmelee rulepak

### DIFF
--- a/Core/DefInjected/RulePackDef/RulePacks_CombatMelee.xml
+++ b/Core/DefInjected/RulePackDef/RulePacks_CombatMelee.xml
@@ -32,12 +32,12 @@
     <li>deflecting->glancing</li>
   -->
   <Combat_Deflect.rulePack.rulesStrings>
-    <li>r_logentry(p=0.5)->[INITIATOR_definite] [damaged_past] [RECIPIENT_definite] in [RECIPIENT_possessive] [recipient_part0_label] [deflected_result].</li>
-    <li>r_logentry(p=0.3)->[INITIATOR_definite] [damaged_past] [RECIPIENT_definite] [skillAdvMaybe] met [implement] [deflected_result].</li>
-    <li>r_logentry(p=0.3)->[INITIATOR_definite] [damaged_past] [RECIPIENT_definite] [skillAdvMaybe] [deflected_result].</li>
-    <li>r_logentry(p=0.1)->[INITIATOR_definite], [skillDescMelee], [damaged_past] [RECIPIENT_definite] in [RECIPIENT_possessive] [recipient_part0_label] [deflected_result].</li>
-    <li>r_logentry(p=0.1)->[INITIATOR_definite] raakte [RECIPIENT_definite] met een [damaged_inf] van [implement] [deflected_result].</li>
-    <li>r_logentry(p=0.1)->[INITIATOR_definite] [skillAdvMaybe] gebruikte [implement] om [RECIPIENT_definite] te [damaged_inf] [deflected_result].</li>
+    <li>r_logentry(p=0.5)->[INITIATOR_label] [damaged_past] [RECIPIENT_label] in [RECIPIENT_possessive] [recipient_part0_label] [deflected_result].</li>
+    <li>r_logentry(p=0.3)->[INITIATOR_label] [damaged_past] [RECIPIENT_label] [skillAdvMaybe] met [implement] [deflected_result].</li>
+    <li>r_logentry(p=0.3)->[INITIATOR_label] [damaged_past] [RECIPIENT_label] [skillAdvMaybe] [deflected_result].</li>
+    <li>r_logentry(p=0.1)->[INITIATOR_label], [skillDescMelee], [damaged_past] [RECIPIENT_label] in [RECIPIENT_possessive] [recipient_part0_label] [deflected_result].</li>
+    <li>r_logentry(p=0.1)->[INITIATOR_label] raakte [RECIPIENT_label] met een [damaged_inf] van [implement] [deflected_result].</li>
+    <li>r_logentry(p=0.1)->[INITIATOR_label] [skillAdvMaybe] gebruikte [implement] om [RECIPIENT_label] te [damaged_inf] [deflected_result].</li>
     <li>skillAdvMaybe-></li>
     <li>skillAdvMaybe->[skillAdv]</li>
     <li>deflected_result->, maar [INITIATOR_possessive] [TOOL_label] [deflected]</li>
@@ -61,8 +61,8 @@
     <li>result->but the attack was cleverly avoided</li>
   -->
   <Combat_Dodge.rulePack.rulesStrings>
-    <li>r_logentry(p=0.5)->[RECIPIENT_definite] ontweek [skillAdvMaybe] [INITIATOR_definite]'s [damaged_inf] door [implement].</li>
-    <li>r_logentry(p=0.5)->[RECIPIENT_definite] ontweek [skillAdvMaybe] [INITIATOR_definite]'s [damaged_inf].</li>
+    <li>r_logentry(p=0.5)->[RECIPIENT_label] ontweek [skillAdvMaybe] [INITIATOR_label]'s [damaged_inf] door [implement].</li>
+    <li>r_logentry(p=0.5)->[RECIPIENT_label] ontweek [skillAdvMaybe] [INITIATOR_label]'s [damaged_inf].</li>
     <li>skillAdvMaybe-></li>
     <li>skillAdvMaybe->[skillAdv]</li>
     <li>result->maar [RECIPIENT_definite] sprong opzij</li>
@@ -93,26 +93,26 @@
     <li>action(p=0.3)->[INITIATOR_definite] used [implement] [skillAdv] to [damaged_inf] [RECIPIENT_definite]</li>
   -->
   <Combat_Hit.rulePack.rulesStrings>
-    <li>r_logentry(p=1.0)->[INITIATOR_definite] [damaged_past] [RECIPIENT_definite] in [RECIPIENT_possessive] [recipient_part0_label].</li>
-    <li>r_logentry(p=0.4)->[INITIATOR_definite] [damaged_past] [RECIPIENT_definite] in [RECIPIENT_possessive] [recipient_part0_label] [strikeAdv].</li>
-    <li>r_logentry(p=0.4)->[INITIATOR_definite] [damaged_past] [RECIPIENT_definite] in [RECIPIENT_possessive] [recipient_part0_label], [flavortext_consequence].</li>
-    <li>r_logentry(p=0.4)->[INITIATOR_definite], [skillDescMelee], [damaged_past] [RECIPIENT_definite] in [RECIPIENT_possessive] [recipient_part0_label].</li>
-    <li>r_logentry(p=0.2)->[INITIATOR_definite], [skillDescMelee], [damaged_past] [strikeAdv] [RECIPIENT_definite] in [RECIPIENT_possessive] [recipient_part0_label].</li>
-    <li>r_logentry(p=0.4)->[INITIATOR_definite] [destroyed_past] [RECIPIENT_definite]'s [destroyed_targets].</li>
-    <li>r_logentry(p=0.4)->[INITIATOR_definite] [destroyed_past] [RECIPIENT_definite]'s [destroyed_targets] [destroyed_suffix].</li>
-    <li>r_logentry(p=0.4)->[INITIATOR_definite] [destroyed_past] [RECIPIENT_definite]'s [destroyed_targets] met [implement].</li>
-    <li>r_logentry(p=1,recipient_part_count==0)->[INITIATOR_definite] [damaged_past] [RECIPIENT_definite] met [implement].</li>
-    <li>r_logentry(p=0.4,recipient_part_count==0)->[INITIATOR_definite] [damaged_past] [skillAdv] [RECIPIENT_definite] met [implement].</li>
+    <li>r_logentry(p=1.0)->[INITIATOR_label] [damaged_past] [RECIPIENT_label] in [RECIPIENT_possessive] [recipient_part0_label].</li>
+    <li>r_logentry(p=0.4)->[INITIATOR_label] [damaged_past] [RECIPIENT_label] in [RECIPIENT_possessive] [recipient_part0_label] [strikeAdv].</li>
+    <li>r_logentry(p=0.4)->[INITIATOR_label] [damaged_past] [RECIPIENT_label] in [RECIPIENT_possessive] [recipient_part0_label], [flavortext_consequence].</li>
+    <li>r_logentry(p=0.4)->[INITIATOR_label], [skillDescMelee], [damaged_past] [RECIPIENT_label] in [RECIPIENT_possessive] [recipient_part0_label].</li>
+    <li>r_logentry(p=0.2)->[INITIATOR_label], [skillDescMelee], [damaged_past] [strikeAdv] [RECIPIENT_label] in [RECIPIENT_possessive] [recipient_part0_label].</li>
+    <li>r_logentry(p=0.4)->[INITIATOR_label] [destroyed_past] [RECIPIENT_label]'s [destroyed_targets].</li>
+    <li>r_logentry(p=0.4)->[INITIATOR_label] [destroyed_past] [RECIPIENT_label]'s [destroyed_targets] [destroyed_suffix].</li>
+    <li>r_logentry(p=0.4)->[INITIATOR_label] [destroyed_past] [RECIPIENT_label]'s [destroyed_targets] met [implement].</li>
+    <li>r_logentry(p=1,recipient_part_count==0)->[INITIATOR_label] [damaged_past] [RECIPIENT_label] met [implement].</li>
+    <li>r_logentry(p=0.4,recipient_part_count==0)->[INITIATOR_label] [damaged_past] [skillAdv] [RECIPIENT_label] met [implement].</li>
     <li>result(p=1,recipient_part_damaged_count==0)->en [destroyed_past] [RECIPIENT_possessive] [destroyed_targets]</li>
     <li>result(p=1,recipient_part_destroyed_count==0)->en [damaged_past] [RECIPIENT_possessive] [damaged_targets]</li>
     <li>result(p=1)->en [destroyed_past] [RECIPIENT_possessive] [destroyed_targets] en [damaged_past] [RECIPIENT_possessive] [damaged_targets]</li>
-    <li>action(p=1.0)->[INITIATOR_definite] [damaged_past] [RECIPIENT_definite] met [implement]</li>
-    <li>action(p=0.3)->[INITIATOR_definite] [damaged_past] [RECIPIENT_definite]</li>
-    <li>action(p=0.3)->[INITIATOR_definite], [skillDescMelee], [damaged_past] [RECIPIENT_definite]</li>
-    <li>action(p=0.3)->[INITIATOR_definite] raakte [RECIPIENT_definite] met een [damaged_inf] van [implement]</li>
-    <li>action(p=0.3)->[INITIATOR_definite], [skillDescMelee], raakte [RECIPIENT_definite] met een [damaged_inf] van [implement]</li>
-    <li>action(p=0.3)->[INITIATOR_definite] gebruikte [INITIATOR_possessive] [implement] om [RECIPIENT_definite] te [damaged_inf]</li>
-    <li>action(p=0.3)->[INITIATOR_definite] gebruikte [skillAdv] [INITIATOR_possessive] [implement] om [RECIPIENT_definite] te [damaged_inf]</li>
+    <li>action(p=1.0)->[INITIATOR_label] [damaged_past] [RECIPIENT_label] met [implement]</li>
+    <li>action(p=0.3)->[INITIATOR_label] [damaged_past] [RECIPIENT_label]</li>
+    <li>action(p=0.3)->[INITIATOR_label], [skillDescMelee], [damaged_past] [RECIPIENT_label]</li>
+    <li>action(p=0.3)->[INITIATOR_label] raakte [RECIPIENT_label] met een [damaged_inf] van [implement]</li>
+    <li>action(p=0.3)->[INITIATOR_label], [skillDescMelee], raakte [RECIPIENT_label] met een [damaged_inf] van [implement]</li>
+    <li>action(p=0.3)->[INITIATOR_label] gebruikte [INITIATOR_possessive] [implement] om [RECIPIENT_label] te [damaged_inf]</li>
+    <li>action(p=0.3)->[INITIATOR_label] gebruikte [skillAdv] [INITIATOR_possessive] [implement] om [RECIPIENT_label] te [damaged_inf]</li>
   </Combat_Hit.rulePack.rulesStrings>
   
   <!-- EN:
@@ -135,11 +135,11 @@
     <li>result(initiator_flesh!=Mechanoid)->but hesitated at the last second</li>
   -->
   <Combat_Miss.rulePack.rulesStrings>
-    <li>r_logentry(p=0.3)->[RECIPIENT_definite] ontweek [INITIATOR_definite]'s [WEAPON_label] [damaged_inf].</li>
-    <li>r_logentry(p=0.3)->[INITIATOR_definite] miste [RECIPIENT_definite] met een [damaged_inf] van [implement].</li>
-    <li>r_logentry(p=0.3)->[INITIATOR_definite] [failtype] tijdens een poging om [RECIPIENT_definite] te [damaged_inf] met [implement].</li>
-    <li>r_logentry(p=0.3)->[INITIATOR_definite] [failtype] toen [INITIATOR_pronoun] probeerde [RECIPIENT_definite] te [damaged_inf].</li>
-    <li>r_logentry(p=0.3)->[INITIATOR_definite] probeerde [skillAdvMaybe] om [RECIPIENT_definite] te [damaged_inf], maar [failtype].</li>
+    <li>r_logentry(p=0.3)->[RECIPIENT_label] ontweek [INITIATOR_label]'s [WEAPON_label] [damaged_inf].</li>
+    <li>r_logentry(p=0.3)->[INITIATOR_label] miste [RECIPIENT_label] met een [damaged_inf] van [implement].</li>
+    <li>r_logentry(p=0.3)->[INITIATOR_label] [failtype] tijdens een poging om [RECIPIENT_label] te [damaged_inf] met [implement].</li>
+    <li>r_logentry(p=0.3)->[INITIATOR_label] [failtype] toen [INITIATOR_pronoun] probeerde [RECIPIENT_label] te [damaged_inf].</li>
+    <li>r_logentry(p=0.3)->[INITIATOR_label] probeerde [skillAdvMaybe] om [RECIPIENT_label] te [damaged_inf], maar [failtype].</li>
     <li>skillAdvMaybe-></li>
     <li>skillAdvMaybe->[skillAdv]</li>
     <li>failtype(p=5)->miste</li>

--- a/Core/DefInjected/RulePackDef/RulePacks_CombatRanged.xml
+++ b/Core/DefInjected/RulePackDef/RulePacks_CombatRanged.xml
@@ -34,28 +34,28 @@
     <li>fromof->of</li>
   -->
   <Combat_ExplosionImpact.rulePack.rulesStrings>
-    <li>prefix->De [blast] van [INITIATOR_definite]'s [WEAPON_projectile_label]</li>
-    <li>prefix->De [blast] van [INITIATOR_definite]'s [WEAPON_label]</li>
-    <li>prefix->De [blast] van [INITIATOR_definite]'s [WEAPON_projectile_label]</li>
-    <li>prefix->De [blast] van [INITIATOR_definite]'s [WEAPON_label]</li>
-    <li>prefix->[INITIATOR_definite]'s [blast]</li>
-    <li>prefix->[INITIATOR_definite]'s [WEAPON_projectile_label] [blast]</li>
-    <li>prefix->[INITIATOR_definite]'s [WEAPON_label] [blast]</li>
-    <li>prefix->[INITIATOR_definite]'s [WEAPON_projectile_label]</li>
-    <li>prefix->[INITIATOR_definite]'s [WEAPON_label]</li>
-    <li>r_logentry->[prefix] [injured] [RECIPIENT_definite].</li>
-    <li>r_logentry->[prefix] [destroyed_past] [RECIPIENT_definite]'s [destroyed_targets].</li>
-    <li>r_logentry->[prefix] [destroyed_past] [RECIPIENT_definite]'s [destroyed_targets] [strikeAdv].</li>
-    <li>r_logentry->[prefix] [strikeAdv] [destroyed_past] [RECIPIENT_definite]'s [destroyed_targets].</li>
-    <li>r_logentry->[prefix] [destroyed_past] [RECIPIENT_definite]'s [destroyed_targets] and [damaged_past] [RECIPIENT_possessive] [damaged_targets].</li>
-    <li>r_logentry(recipient_part_destroyed_count==0)->[prefix] [damaged_past] [RECIPIENT_definite]'s [damaged_targets].</li>
-    <li>r_logentry(recipient_part_destroyed_count==0)->[prefix] [damaged_past] [RECIPIENT_definite]'s [damaged_targets] [strikeAdv].</li>
-    <li>r_logentry(recipient_part_destroyed_count==0)->[prefix] [strikeAdv] [damaged_past] [RECIPIENT_definite]'s [damaged_targets].</li>
-    <li>r_logentry->[RECIPIENT_definite] werd [damaged_pastperf] door [INITIATOR_definite].</li>
-    <li>r_logentry->[RECIPIENT_definite] werd [strikeAdv] [damaged_pastperf] door [INITIATOR_definite].</li>
-    <li>r_logentry->[RECIPIENT_definite] werd [damaged_pastperf].</li>
-    <li>r_logentry(p=0.001)->[RECIPIENT_definite] werd geraakt door een explosie.</li>
-    <li>r_logentry(p=0.001)->[RECIPIENT_definite] kwam terecht in een explosie.</li>
+    <li>prefix->De [blast] van [INITIATOR_label]'s [WEAPON_projectile_label]</li>
+    <li>prefix->De [blast] van [INITIATOR_label]'s [WEAPON_label]</li>
+    <li>prefix->De [blast] van [INITIATOR_label]'s [WEAPON_projectile_label]</li>
+    <li>prefix->De [blast] van [INITIATOR_label]'s [WEAPON_label]</li>
+    <li>prefix->[INITIATOR_label]'s [blast]</li>
+    <li>prefix->[INITIATOR_label]'s [WEAPON_projectile_label] [blast]</li>
+    <li>prefix->[INITIATOR_label]'s [WEAPON_label] [blast]</li>
+    <li>prefix->[INITIATOR_label]'s [WEAPON_projectile_label]</li>
+    <li>prefix->[INITIATOR_label]'s [WEAPON_label]</li>
+    <li>r_logentry->[prefix] [injured] [RECIPIENT_label].</li>
+    <li>r_logentry->[prefix] [destroyed_past] [RECIPIENT_label]'s [destroyed_targets].</li>
+    <li>r_logentry->[prefix] [destroyed_past] [RECIPIENT_label]'s [destroyed_targets] [strikeAdv].</li>
+    <li>r_logentry->[prefix] [strikeAdv] [destroyed_past] [RECIPIENT_label]'s [destroyed_targets].</li>
+    <li>r_logentry->[prefix] [destroyed_past] [RECIPIENT_label]'s [destroyed_targets] and [damaged_past] [RECIPIENT_possessive] [damaged_targets].</li>
+    <li>r_logentry(recipient_part_destroyed_count==0)->[prefix] [damaged_past] [RECIPIENT_label]'s [damaged_targets].</li>
+    <li>r_logentry(recipient_part_destroyed_count==0)->[prefix] [damaged_past] [RECIPIENT_label]'s [damaged_targets] [strikeAdv].</li>
+    <li>r_logentry(recipient_part_destroyed_count==0)->[prefix] [strikeAdv] [damaged_past] [RECIPIENT_label]'s [damaged_targets].</li>
+    <li>r_logentry->[RECIPIENT_label] werd [damaged_pastperf] door [INITIATOR_label].</li>
+    <li>r_logentry->[RECIPIENT_label] werd [strikeAdv] [damaged_pastperf] door [INITIATOR_label].</li>
+    <li>r_logentry->[RECIPIENT_label] werd [damaged_pastperf].</li>
+    <li>r_logentry(p=0.001)->[RECIPIENT_label] werd geraakt door een explosie.</li>
+    <li>r_logentry(p=0.001)->[RECIPIENT_label] kwam terecht in een explosie.</li>
     <li>blast->explosie</li>
     <li>blast->knal</li>
     <li>blast->schokgolf</li>
@@ -122,23 +122,23 @@
     <li>missed->narrowly missed</li>
   -->
   <Combat_RangedDamage.rulePack.rulesStrings>
-    <li>r_logentry->[INITIATOR_definite]'s [WEAPON_projectile_label] [destroyed_past] [RECIPIENT_definite]'s [destroyed_targets].</li>
-    <li>r_logentry->[INITIATOR_definite]'s [WEAPON_projectile_label] [destroyed_past] [RECIPIENT_definite]'s [destroyed_targets] [destroyed_suffix].</li>
-    <li>r_logentry(p=2)->[INITIATOR_definite]'s [WEAPON_projectile_label] [missed] [ORIGINALTARGET_definite] en [destroyed_past] [RECIPIENT_definite]'s [destroyed_targets].</li>
-    <li>r_logentry(p=2)->[INITIATOR_definite]'s [WEAPON_projectile_label] [missed] [ORIGINALTARGET_definite], maar [destroyed_past] [RECIPIENT_definite]'s [destroyed_targets].</li>
-    <li>r_logentry->[RECIPIENT_definite]'s [destroyed_targets] werd [destroyed_pastperfect] door [INITIATOR_definite]'s [WEAPON_projectile_label].</li>
-    <li>r_logentry->[RECIPIENT_definite]'s [destroyed_targets] werd [destroyed_pastperfect] [destroyed_suffix] door [INITIATOR_definite]'s [WEAPON_projectile_label].</li>
-    <li>r_logentry(recipient_part_destroyed_count==0)->[INITIATOR_definite]'s [WEAPON_projectile_label] [damaged_past] [RECIPIENT_definite]'s [damaged_targets].</li>
-    <li>r_logentry(recipient_part_destroyed_count==0,p=2)->[INITIATOR_definite]'s [WEAPON_projectile_label] [missed] [ORIGINALTARGET_definite] en [damaged_past] [RECIPIENT_definite]'s [damaged_targets].</li>
-    <li>r_logentry(recipient_part_destroyed_count==0,p=2)->[INITIATOR_definite]'s [WEAPON_projectile_label] [missed] [ORIGINALTARGET_definite], maar [damaged_past] [RECIPIENT_definite]'s [damaged_targets].</li>
-    <li>r_logentry(recipient_part_destroyed_count==0)->[RECIPIENT_definite]'s [damaged_targets] werd [damaged_past] by [INITIATOR_definite]'s [WEAPON_projectile_label].</li>
-    <li>r_logentry(p=3)->[INITIATOR_definite]'s [WEAPON_projectile_label] [destroyed_past] [RECIPIENT_definite]'s [destroyed_targets] en [damaged_past] [RECIPIENT_possessive] [damaged_targets].</li>
-    <li>r_logentry(p=6)->[INITIATOR_definite]'s [WEAPON_projectile_label] [missed] [ORIGINALTARGET_definite], maar [destroyed_past] [RECIPIENT_definite]'s [destroyed_targets] en [damaged_past] [RECIPIENT_possessive] [damaged_targets].</li>
-    <li>r_logentry(p=0.2)->[INITIATOR_definite] raakte [RECIPIENT_definite] met een [WEAPON_projectile_label].</li>
-    <li>r_logentry(p=0.2)->[INITIATOR_definite]'s [WEAPON_projectile_label] raakte [RECIPIENT_definite].</li>
-    <li>r_logentry(p=0.4)->[INITIATOR_definite] [missed] [ORIGINALTARGET_definite] en raakte [RECIPIENT_definite] met een [WEAPON_projectile_label].</li>
-    <li>r_logentry(p=0.4)->[INITIATOR_definite]'s [WEAPON_projectile_label] [missed] [ORIGINALTARGET_definite] en raakte [RECIPIENT_definite].</li>
-    <li>r_logentry(p=0.2)->[INITIATOR_definite] raakte [RECIPIENT_definite] met een [WEAPON_projectile_label] die was bedoeld voor [ORIGINALTARGET_definite].</li>
+    <li>r_logentry->[INITIATOR_label]'s [WEAPON_projectile_label] [destroyed_past] [RECIPIENT_label]'s [destroyed_targets].</li>
+    <li>r_logentry->[INITIATOR_label]'s [WEAPON_projectile_label] [destroyed_past] [RECIPIENT_label]'s [destroyed_targets] [destroyed_suffix].</li>
+    <li>r_logentry(p=2)->[INITIATOR_label]'s [WEAPON_projectile_label] [missed] [ORIGINALTARGET_label] en [destroyed_past] [RECIPIENT_label]'s [destroyed_targets].</li>
+    <li>r_logentry(p=2)->[INITIATOR_label]'s [WEAPON_projectile_label] [missed] [ORIGINALTARGET_label], maar [destroyed_past] [RECIPIENT_label]'s [destroyed_targets].</li>
+    <li>r_logentry->[RECIPIENT_label]'s [destroyed_targets] werd [destroyed_pastperfect] door [INITIATOR_label]'s [WEAPON_projectile_label].</li>
+    <li>r_logentry->[RECIPIENT_label]'s [destroyed_targets] werd [destroyed_pastperfect] [destroyed_suffix] door [INITIATOR_label]'s [WEAPON_projectile_label].</li>
+    <li>r_logentry(recipient_part_destroyed_count==0)->[INITIATOR_label]'s [WEAPON_projectile_label] [damaged_past] [RECIPIENT_label]'s [damaged_targets].</li>
+    <li>r_logentry(recipient_part_destroyed_count==0,p=2)->[INITIATOR_label]'s [WEAPON_projectile_label] [missed] [ORIGINALTARGET_label] en [damaged_past] [RECIPIENT_label]'s [damaged_targets].</li>
+    <li>r_logentry(recipient_part_destroyed_count==0,p=2)->[INITIATOR_label]'s [WEAPON_projectile_label] [missed] [ORIGINALTARGET_label], maar [damaged_past] [RECIPIENT_label]'s [damaged_targets].</li>
+    <li>r_logentry(recipient_part_destroyed_count==0)->[RECIPIENT_label]'s [damaged_targets] werd [damaged_past] by [INITIATOR_label]'s [WEAPON_projectile_label].</li>
+    <li>r_logentry(p=3)->[INITIATOR_label]'s [WEAPON_projectile_label] [destroyed_past] [RECIPIENT_label]'s [destroyed_targets] en [damaged_past] [RECIPIENT_possessive] [damaged_targets].</li>
+    <li>r_logentry(p=6)->[INITIATOR_label]'s [WEAPON_projectile_label] [missed] [ORIGINALTARGET_label], maar [destroyed_past] [RECIPIENT_label]'s [destroyed_targets] en [damaged_past] [RECIPIENT_possessive] [damaged_targets].</li>
+    <li>r_logentry(p=0.2)->[INITIATOR_label] raakte [RECIPIENT_label] met een [WEAPON_projectile_label].</li>
+    <li>r_logentry(p=0.2)->[INITIATOR_label]'s [WEAPON_projectile_label] raakte [RECIPIENT_label].</li>
+    <li>r_logentry(p=0.4)->[INITIATOR_label] [missed] [ORIGINALTARGET_label] en raakte [RECIPIENT_label] met een [WEAPON_projectile_label].</li>
+    <li>r_logentry(p=0.4)->[INITIATOR_label]'s [WEAPON_projectile_label] [missed] [ORIGINALTARGET_label] en raakte [RECIPIENT_label].</li>
+    <li>r_logentry(p=0.2)->[INITIATOR_label] raakte [RECIPIENT_label] met een [WEAPON_projectile_label] die was bedoeld voor [ORIGINALTARGET_label].</li>
     <li>weapon_projectile_label(p=0.05)->shot</li>
     <li>destroyed_past->verbrijzelde</li>
     <li>destroyed_past->verpulverde</li>
@@ -196,14 +196,14 @@
     <li>missed->narrowly missed</li>
   -->
   <Combat_RangedDeflect.rulePack.rulesStrings>
-    <li>r_logentry->[INITIATOR_definite]'s [WEAPON_projectile_label] [damaged_past] [RECIPIENT_definite][damaged_target] [deflected_result].</li>
-    <li>r_logentry(p=2)->[INITIATOR_definite]'s [WEAPON_projectile_label] [missed] [ORIGINALTARGET_definite] en [damaged_past] [RECIPIENT_definite][damaged_target_possessive_opt] [deflected_result].</li>
-    <li>r_logentry->[RECIPIENT_definite][damaged_target_possessive_opt] werd [damaged_pastperfect] door [INITIATOR_definite]'s [WEAPON_projectile_label] [deflected_result].</li>
-    <li>r_logentry(p=0.2)->[INITIATOR_definite] raakte [RECIPIENT_definite][damaged_target_possessive_opt] met een [WEAPON_projectile_label] [deflected_result].</li>
-    <li>r_logentry(p=0.2)->[INITIATOR_definite]'s [WEAPON_projectile_label] raakte [RECIPIENT_definite][damaged_target_possessive_opt] [deflected_result].</li>
-    <li>r_logentry(p=0.4)->[INITIATOR_definite] [missed] [ORIGINALTARGET_definite] en raakte [RECIPIENT_definite][damaged_target_possessive_opt] met een [WEAPON_projectile_label] [deflected_result].</li>
-    <li>r_logentry(p=0.4)->[INITIATOR_definite]'s [WEAPON_projectile_label] [missed] [ORIGINALTARGET_definite] en raakte [RECIPIENT_definite][damaged_target_possessive_opt] [deflected_result].</li>
-    <li>r_logentry(p=0.2)->[INITIATOR_definite] raakte [RECIPIENT_definite][damaged_target_possessive_opt] met een [WEAPON_projectile_label] die bedoeld was voor [ORIGINALTARGET_definite] [deflected_result].</li>
+    <li>r_logentry->[INITIATOR_label]'s [WEAPON_projectile_label] [damaged_past] [RECIPIENT_label][damaged_target] [deflected_result].</li>
+    <li>r_logentry(p=2)->[INITIATOR_label]'s [WEAPON_projectile_label] [missed] [ORIGINALTARGET_label] en [damaged_past] [RECIPIENT_label][damaged_target_possessive_opt] [deflected_result].</li>
+    <li>r_logentry->[RECIPIENT_label][damaged_target_possessive_opt] werd [damaged_pastperfect] door [INITIATOR_label]'s [WEAPON_projectile_label] [deflected_result].</li>
+    <li>r_logentry(p=0.2)->[INITIATOR_label] raakte [RECIPIENT_label][damaged_target_possessive_opt] met een [WEAPON_projectile_label] [deflected_result].</li>
+    <li>r_logentry(p=0.2)->[INITIATOR_label]'s [WEAPON_projectile_label] raakte [RECIPIENT_label][damaged_target_possessive_opt] [deflected_result].</li>
+    <li>r_logentry(p=0.4)->[INITIATOR_label] [missed] [ORIGINALTARGET_label] en raakte [RECIPIENT_label][damaged_target_possessive_opt] met een [WEAPON_projectile_label] [deflected_result].</li>
+    <li>r_logentry(p=0.4)->[INITIATOR_label]'s [WEAPON_projectile_label] [missed] [ORIGINALTARGET_label] en raakte [RECIPIENT_label][damaged_target_possessive_opt] [deflected_result].</li>
+    <li>r_logentry(p=0.2)->[INITIATOR_label] raakte [RECIPIENT_label][damaged_target_possessive_opt] met een [WEAPON_projectile_label] die bedoeld was voor [ORIGINALTARGET_label] [deflected_result].</li>
     <li>weapon_projectile_label(p=0.05)->raakte</li>
     <li>damaged_target_possessive_opt-></li>
     <li>damaged_target_possessive_opt(recipient_part_damaged0_outside==True)->'s [recipient_part_damaged0_label]</li>
@@ -249,12 +249,12 @@
     <li>verb_shot(p=0.2)->discharged</li>
   -->
   <Combat_RangedFire.rulePack.rulesStrings>
-    <li>r_logentry->[INITIATOR_definite] [shotat] [RECIPIENT_definite] with [INITIATOR_possessive] [WEAPON_label].</li>
-    <li>r_logentry->[INITIATOR_definite] [shot] met [INITIATOR_possessive] [WEAPON_label] op [RECIPIENT_definite].</li>
-    <li>r_logentry->[INITIATOR_definite] [shotat] [RECIPIENT_definite].</li>
-    <li>r_logentry->[INITIATOR_definite] [shot] [aburst] met [INITIATOR_possessive] [WEAPON_label] op [RECIPIENT_definite].</li>
-    <li>r_logentry(RECIPIENT_missing==True)->[INITIATOR_definite] [shot_a] [WEAPON_projectile_label].</li>
-    <li>r_logentry(RECIPIENT_missing==True)->[INITIATOR_definite] [shot] met [INITIATOR_possessive] [WEAPON_label].</li>
+    <li>r_logentry->[INITIATOR_label] [shotat] [RECIPIENT_label] with [INITIATOR_possessive] [WEAPON_label].</li>
+    <li>r_logentry->[INITIATOR_label] [shot] met [INITIATOR_possessive] [WEAPON_label] op [RECIPIENT_label].</li>
+    <li>r_logentry->[INITIATOR_label] [shotat] [RECIPIENT_label].</li>
+    <li>r_logentry->[INITIATOR_label] [shot] [aburst] met [INITIATOR_possessive] [WEAPON_label] op [RECIPIENT_label].</li>
+    <li>r_logentry(RECIPIENT_missing==True)->[INITIATOR_label] [shot_a] [WEAPON_projectile_label].</li>
+    <li>r_logentry(RECIPIENT_missing==True)->[INITIATOR_label] [shot] met [INITIATOR_possessive] [WEAPON_label].</li>
     <li>shot_a(p=2)->[verb_shot] een</li>
     <li>shot_a->[verb_shot] [skillAdv] een</li>
     <li>shot(p=2)->[verb_shot]</li>
@@ -302,10 +302,10 @@
     <li>adjective_threw(initiator_flesh!=Mechanoid)->wary</li>
   -->
   <Combat_RangedFire_Thrown.rulePack.rulesStrings>
-    <li>r_logentry->[INITIATOR_definite] [threw] [INITIATOR_possessive] [WEAPON_projectile_label] naar [RECIPIENT_definite].</li>
-    <li>r_logentry->[INITIATOR_definite] [threw_a] [WEAPON_projectile_label] naar [RECIPIENT_definite].</li>
-    <li>r_logentry(RECIPIENT_missing==True)->[INITIATOR_definite] [threw] [INITIATOR_possessive] [WEAPON_projectile_label].</li>
-    <li>r_logentry(RECIPIENT_missing==True)->[INITIATOR_definite] [threw_a] [WEAPON_projectile_label].</li>
+    <li>r_logentry->[INITIATOR_label] [threw] [INITIATOR_possessive] [WEAPON_projectile_label] naar [RECIPIENT_label].</li>
+    <li>r_logentry->[INITIATOR_label] [threw_a] [WEAPON_projectile_label] naar [RECIPIENT_label].</li>
+    <li>r_logentry(RECIPIENT_missing==True)->[INITIATOR_label] [threw] [INITIATOR_possessive] [WEAPON_projectile_label].</li>
+    <li>r_logentry(RECIPIENT_missing==True)->[INITIATOR_label] [threw_a] [WEAPON_projectile_label].</li>
     <li>threw_a->[adverb_threw] [verb_threw] een</li>
     <li>threw_a(p=2)->[verb_threw] een</li>
     <li>threw(p=2)->[verb_threw]</li>
@@ -366,9 +366,9 @@
     <li>ducked->hid</li>
   -->
   <Combat_RangedMiss.rulePack.rulesStrings>
-    <li>r_logentry->[INITIATOR_definite]'s [WEAPON_projectile_label] [missed_pre].</li>
-    <li>r_logentry->[INITIATOR_definite] miste [ORIGINALTARGET_definite].</li>
-    <li>r_logentry->[ORIGINALTARGET_definite] [avoidance], waardoor [INITIATOR_definite]'s [WEAPON_projectile_label] [missed_post].</li>
+    <li>r_logentry->[INITIATOR_label]'s [WEAPON_projectile_label] [missed_pre].</li>
+    <li>r_logentry->[INITIATOR_label] miste [ORIGINALTARGET_label].</li>
+    <li>r_logentry->[ORIGINALTARGET_label] [avoidance], waardoor [INITIATOR_label]'s [WEAPON_projectile_label] [missed_post].</li>
     <li>missed_pre->miste</li>
     <li>missed_pre->miste ternauwernood</li>
     <li>missed_pre->miste ruim</li>
@@ -378,9 +378,9 @@
     <li>missed_pre->boorde zich de grond in</li>
     <li>missed_pre->ketste tegen de grond en ging verloren</li>
     <li>missed_pre->trok een geul door de grond</li>
-    <li>missed_pre(p=0.2)->vloog op millimeters afstand langs [ORIGINALTARGET_definite]</li>
-    <li>missed_pre->vloog op centimeters afstand langs [ORIGINALTARGET_definite]</li>
-    <li>missed_pre->vloog op minder dan een meter langs [ORIGINALTARGET_definite]</li>
+    <li>missed_pre(p=0.2)->vloog op millimeters afstand langs [ORIGINALTARGET_label]</li>
+    <li>missed_pre->vloog op centimeters afstand langs [ORIGINALTARGET_label]</li>
+    <li>missed_pre->vloog op minder dan een meter langs [ORIGINALTARGET_label]</li>
     <li>missed_pre->waaide van koers af</li>
     <li>missed_post->miste</li>
     <li>missed_post->ternauwernood miste</li>
@@ -391,9 +391,9 @@
     <li>missed_post->zich de grond in boorde</li>
     <li>missed_post->tegen de grond ketste en verloren ging</li>
     <li>missed_post->een geul door de grond trok</li>
-    <li>missed_post(p=0.2)->op millimeters afstand langs [ORIGINALTARGET_definite] vloog</li>
-    <li>missed_post->op centimeters afstand langs [ORIGINALTARGET_definite] vloog</li>
-    <li>missed_post->op minder dan een meter langs [ORIGINALTARGET_definite] vloog</li>
+    <li>missed_post(p=0.2)->op millimeters afstand langs [ORIGINALTARGET_label] vloog</li>
+    <li>missed_post->op centimeters afstand langs [ORIGINALTARGET_label] vloog</li>
+    <li>missed_post->op minder dan een meter langs [ORIGINALTARGET_label] vloog</li>
     <li>missed_post->van koers af waaide</li>
     <li>avoidance(ORIGINALTARGET_mobile==True,p=2)->[moved] opzij op [moment]</li>
     <li>avoidance(ORIGINALTARGET_mobile==True,p=0.3)->[ducked] achter [COVER_definite]</li>


### PR DESCRIPTION
Ik heb bekeken hoe ze het in het Duits hebben opgelost (m.i. goede inspiratie vanwege de vergelijkbare grammatica), daar gebruiken ze _label ipv _definite zoals het in het Engels wordt gebruikt.

Het resultaat is iets minder fraai dan de juiste lidwoorden gebruiken, maar ik denk wel dat het beter is dan dat de verkeerde lidwoorden worden gebruikt.

> **Maaier** probeerde om **Bear** met zijn monosword te slaan, maar de aanval werd handig ontweken.
> **Maaier** hakte **Arseny** met zijn gladius's lemmet, maar zijn pantser weerde de aanval af..
> **Bardanes** sneed schuw **Pratt** met een langzwaard's kling.
> **Redfields** deed een poging om **chinchilla** met een langzwaard's kling te slaan, maar liet zich door de **chinchilla**'s schijnbeweging misleiden.
> **Lansier** probeerde om **Meteredus** met een gladius's lemmet te steken, maar raakte alleen de lucht.
> **Vecovera** probeerde om **Diver** met zijn persona monosword's edge te slaan,, maar miste.
> **Sneeuwhaas** sneed **Zwart**, maar haar snede werd afgewend.
> **Boxen** ontweek **Topla**'s steken.
> **Stier** hakte **Lise** met zijn persona monosword's edge, maar zijn pantser weerde de aanval af..
> **Neushoorn** gebruikte haar plasmasword om **yorkshire terriër** te steken, maar haar edge ketste af.
> **Piekenier** hakte **Codex** met zijn gladius's lemmet.
> **Jackalope** sloeg **Seara** met haar persona monosword.
> **Merrie** sloeg **hengst** met haar persona monosword's edge, maar zijn pantser weerde de aanval af..
> **Mechanische duizendpoot** gebruikte zijn gladius's lemmet om **Prodromus** te slaan, maar haar pantser weerde de aanval af.
> **Boemrat** hakte **Osros** met haar persona monosword's edge.

CC: @BTAxis ter review.

Als dit voor jou ook akkoord is kunnen we hetzelfde toepassen op CombatRanged.xml